### PR TITLE
Test coverage integration to CI/CD pipeline and reporting for Code Climate Dashboard

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Pushing change
         uses: stefanzweifel/git-auto-commit-action@v4
 
-  Test Coverage:
+  Test_Coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Generating JS Docs
         run: npm run doc
       
-      - name: Pushing changes
-   
+      - name: Pushing change
         uses: stefanzweifel/git-auto-commit-action@v4
 
   Test Coverage:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,9 @@
-name: JSDocs Generation
+name: JSDocs Generation And Test Coverage
 run-name: ${{ github.actor }} is running Github Actions
 on:
+  push:
+    branches:
+          - main     # Only runs on main
   pull_request:
     branches:
           - main     # Only runs on main
@@ -21,4 +24,25 @@ jobs:
         run: npm run doc
       
       - name: Pushing changes
+   
         uses: stefanzweifel/git-auto-commit-action@v4
+
+  Test Coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Installing modules
+        run: npm ci
+
+      - name: Running Tests
+        if: success() || failure()
+        run: npm run GHtest
+
+      - name: Test Coverage
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          export CC_TEST_REPORTER_ID=${{secrets.CC_TEST_REPORTER_ID}}
+          ./cc-test-reporter before-build
+          ./cc-test-reporter after-build -t lcov

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "1.0.0",
 	"scripts": {
 		"test": "jest --detectOpenHandles",
-		"GHtest": "jest -c jest.unit.config.js --testPathPattern=jest_tests/unit_tests",
+		"GHtest": "jest -c jest.unit.config.js --testPathPattern=jest_tests/unit_tests --collectCoverage",
 		"lint": "eslint ./assets/scripts ./jest_tests --fix --ext .js  -c ./.eslintrc.js",
 		"doc": "jsdoc -c ./conf.json"
 	},


### PR DESCRIPTION
- Integrated Test Coverage information with `Jest`.  The coverage information is placed in `lcov` file in the `coverage` directory.  This information is then sent to Code Climate dashboard for reporting and updating the badge in `README.md`.
- `Note:`
   - Further testing and commits might be necessary after this PR is created to resolve any issues, since this will be tested upon PR to `main`